### PR TITLE
GCC compile error fixes

### DIFF
--- a/spriterengine/animation/animation.cpp
+++ b/spriterengine/animation/animation.cpp
@@ -114,7 +114,7 @@ namespace SpriterEngine
 	Timeline *Animation::setVariableTimeline(int objectId, int variableId)
 	{
 		TimelineMap *objectVariables = &variableTimelines[objectId];
-		auto& it = objectVariables->find(variableId);
+		auto it = objectVariables->find(variableId);
 		if (it == objectVariables->end())
 		{
 			return (*objectVariables->insert(std::make_pair(variableId, new Timeline(objectId))).first).second;

--- a/spriterengine/animation/animationinstance.cpp
+++ b/spriterengine/animation/animationinstance.cpp
@@ -99,7 +99,7 @@ namespace SpriterEngine
 	void AnimationInstance::findMainlineKeyTimeForward(real newTime)
 	{
 		auto& currentIt = mainlineKeyIterator;
-		auto& endIt = std::prev(mainlineKeys.end());
+		auto endIt = std::prev(mainlineKeys.end());
 
 		// if the time to find is below the current time
 		if (newTime<(*currentIt)->getTime())
@@ -137,7 +137,7 @@ namespace SpriterEngine
 	void AnimationInstance::findMainlineKeyTimeBackward(real newTime)
 	{
 		auto& currentIt = mainlineKeyIterator;
-		auto& endIt = mainlineKeys.begin();
+		auto endIt = mainlineKeys.begin();
 
 		// if the time to find is above the next time
 		if (newTime > (*currentIt)->getNextTime())

--- a/spriterengine/entity/entity.cpp
+++ b/spriterengine/entity/entity.cpp
@@ -13,8 +13,8 @@ namespace SpriterEngine
 {
 
 	Entity::Entity(std::string initialName, int initialId, FileVector *initialFileVector) :
-		name(initialName),
 		entityId(initialId),
+		name(initialName),
 		files(initialFileVector)
 	{
 	}
@@ -63,7 +63,7 @@ namespace SpriterEngine
 
 	Object * Entity::getObject(int objectId)
 	{
-		auto& it = objectIdMap.find(objectId);
+		auto it = objectIdMap.find(objectId);
 		if (it != objectIdMap.end())
 		{
 			return (*it).second;
@@ -98,7 +98,7 @@ namespace SpriterEngine
 
 	Object * Entity::setSpatialObject(std::string objectName, Object::ObjectType objectType)
 	{
-		auto& it = objectNameMap.find(objectName);
+		auto it = objectNameMap.find(objectName);
 		if (it != objectNameMap.end())
 		{
 			return &(*it).second;
@@ -111,7 +111,7 @@ namespace SpriterEngine
 
 	Object * Entity::setSoundObject(std::string objectName)
 	{
-		auto& it = objectNameMap.find(objectName);
+		auto it = objectNameMap.find(objectName);
 		if (it != objectNameMap.end())
 		{
 			return &(*it).second;
@@ -124,7 +124,7 @@ namespace SpriterEngine
 
 	Object * Entity::setTriggerObject(std::string objectName)
 	{
-		auto& it = objectNameMap.find(objectName);
+		auto it = objectNameMap.find(objectName);
 		if (it != objectNameMap.end())
 		{
 			return &(*it).second;
@@ -137,7 +137,7 @@ namespace SpriterEngine
 
 	Object * Entity::setSubEntityObject(std::string objectName)
 	{
-		auto& it = objectNameMap.find(objectName);
+		auto it = objectNameMap.find(objectName);
 		if (it != objectNameMap.end())
 		{
 			return &(*it).second;
@@ -155,7 +155,7 @@ namespace SpriterEngine
 
 	void Entity::applyCharacterMap(std::string mapName, FileReferenceVector *mappedFiles)
 	{
-		auto& it = characterMaps.find(mapName);
+		auto it = characterMaps.find(mapName);
 		if (it != characterMaps.end())
 		{
 			(*it).second.applyCharacterMap(mappedFiles);
@@ -168,7 +168,7 @@ namespace SpriterEngine
 
 	void Entity::removeAllCharacterMaps(FileReferenceVector *mappedFiles)
 	{
-		auto& mappedFileIt = mappedFiles->begin();
+		auto mappedFileIt = mappedFiles->begin();
 		for (auto& it : *files)
 		{
 			(*mappedFileIt++)->setFile(it);
@@ -183,7 +183,7 @@ namespace SpriterEngine
 
 	UniversalObjectInterface *Entity::getNewObjectInfoInstance(int objectId)
 	{
-		auto& it = objectIdMap.find(objectId);
+		auto it = objectIdMap.find(objectId);
 		if (it != objectIdMap.end())
 		{
 			return (*it).second->getNewObjectInfoInstance();

--- a/spriterengine/entity/entityinstance.cpp
+++ b/spriterengine/entity/entityinstance.cpp
@@ -14,25 +14,25 @@
 namespace SpriterEngine
 {
 	EntityInstance::EntityInstance() :
+		zOrder(0),
 		position(0, 0),
 		scale(1, 1),
 		alpha(1),
 		currentEntity(0),
 		currentAnimation(0),
 		characterMapInterface(0),
-		playbackSpeedRatio(1),
-		zOrder(0)
+		playbackSpeedRatio(1)
 	{
 	}
 	EntityInstance::EntityInstance(SpriterModel *model, Entity *entity, CharacterMapInterface *initialCharacterMapInterface, ObjectFactory *objectFactory) :
+		zOrder(0),
 		position(0, 0),
 		scale(1, 1),
 		alpha(1),
 		currentEntity(0),
 		currentAnimation(0),
 		characterMapInterface(initialCharacterMapInterface),
-		playbackSpeedRatio(1),
-		zOrder(0)
+		playbackSpeedRatio(1)
 	{
 		model->setupFileReferences(&files);
 		currentEntity = &(*entities.insert(std::make_pair(entity->getId(), EntityInstanceData(model, this, entity, objectFactory))).first).second;
@@ -234,7 +234,7 @@ namespace SpriterEngine
 
 	void EntityInstance::setCurrentEntity(int newEntityId)
 	{
-		auto& it = entities.find(newEntityId);
+		auto it = entities.find(newEntityId);
 		if (it != entities.end())
 		{
 			currentEntity = &(*it).second;
@@ -347,7 +347,7 @@ namespace SpriterEngine
 
 	EntityInstanceData * EntityInstance::getEntity(int entityId)
 	{
-		auto& it = entities.find(entityId);
+		auto it = entities.find(entityId);
 		if (it != entities.end())
 		{
 			return &(*it).second;

--- a/spriterengine/entity/entityinstancedata.cpp
+++ b/spriterengine/entity/entityinstancedata.cpp
@@ -24,7 +24,7 @@ namespace SpriterEngine
 
 	UniversalObjectInterface *EntityInstanceData::getObjectInstance(int objectId)
 	{
-		auto& it = objects.find(objectId);
+		auto it = objects.find(objectId);
 		if (it != objects.end())
 		{
 			return (*it).second;
@@ -38,7 +38,7 @@ namespace SpriterEngine
 
 	UniversalObjectInterface *EntityInstanceData::getObjectInstance(std::string objectName)
 	{
-		auto& it = objectNameMap.find(objectName);
+		auto it = objectNameMap.find(objectName);
 		if (it != objectNameMap.end())
 		{
 			return (*it).second;
@@ -52,7 +52,7 @@ namespace SpriterEngine
 
 	TransformProcessor *EntityInstanceData::getTransformer(int id)
 	{
-		auto&  it = transformers.find(id);
+		auto  it = transformers.find(id);
 		if (it != transformers.end())
 		{
 			return &(*it).second;
@@ -84,7 +84,7 @@ namespace SpriterEngine
 
 	VariableInstanceNameAndIdMap *EntityInstanceData::getVariables(int objectId)
 	{
-		auto& it = variables.find(objectId);
+		auto it = variables.find(objectId);
 		if (it != variables.end())
 		{
 			return &(*it).second;
@@ -117,7 +117,7 @@ namespace SpriterEngine
 
 	VariableInstanceNameAndIdMap *EntityInstanceData::getVariables(std::string objectName)
 	{
-		auto&  it = variableObjectNameMap.find(objectName);
+		auto it = variableObjectNameMap.find(objectName);
 		if (it != variableObjectNameMap.end())
 		{
 			return (*it).second;
@@ -150,7 +150,7 @@ namespace SpriterEngine
 
 	UniversalObjectInterface *EntityInstanceData::getTags(int objectId) const
 	{
-		auto& it = tags.find(objectId);
+		auto it = tags.find(objectId);
 		if (it != tags.end())
 		{
 			return (*it).second;
@@ -183,7 +183,7 @@ namespace SpriterEngine
 
 	UniversalObjectInterface *EntityInstanceData::getTags(std::string objectName) const
 	{
-		auto& it = tagObjectNameMap.find(objectName);
+		auto it = tagObjectNameMap.find(objectName);
 		if (it != tagObjectNameMap.end())
 		{
 			return (*it).second;
@@ -211,7 +211,7 @@ namespace SpriterEngine
 
 	UniversalObjectInterface *EntityInstanceData::getTriggerObject(int triggerId)
 	{
-		auto& it = triggers.find(triggerId);
+		auto it = triggers.find(triggerId);
 		if (it != triggers.end())
 		{
 			return (*it).second;
@@ -225,7 +225,7 @@ namespace SpriterEngine
 
 	UniversalObjectInterface *EntityInstanceData::getTriggerObject(std::string triggerName)
 	{
-		auto& it = triggerNameMap.find(triggerName);
+		auto it = triggerNameMap.find(triggerName);
 		if (it != triggerNameMap.end())
 		{
 			return (*it).second;
@@ -239,7 +239,7 @@ namespace SpriterEngine
 
 	UniversalObjectInterface *EntityInstanceData::getSoundObject(int soundId)
 	{
-		auto& it = sounds.find(soundId);
+		auto it = sounds.find(soundId);
 		if (it != sounds.end())
 		{
 			return (*it).second;
@@ -253,7 +253,7 @@ namespace SpriterEngine
 
 	UniversalObjectInterface *EntityInstanceData::getSoundObject(std::string soundName)
 	{
-		auto& it = soundNameMap.find(soundName);
+		auto it = soundNameMap.find(soundName);
 		if (it != soundNameMap.end())
 		{
 			return (*it).second;
@@ -279,7 +279,7 @@ namespace SpriterEngine
 
 	void EntityInstanceData::setCurrentAnimation(const std::string & animationName, AnimationInstance **currentAnimation)
 	{
-		auto& it = animationNameMap.find(animationName);
+		auto it = animationNameMap.find(animationName);
 		if (it != animationNameMap.end())
 		{
 			*currentAnimation = (*it).second;

--- a/spriterengine/entity/entityinstancedata.h
+++ b/spriterengine/entity/entityinstancedata.h
@@ -50,7 +50,7 @@ namespace SpriterEngine
 		UniversalObjectInterface *getObjectInstance(int objectId);
 		UniversalObjectInterface * getObjectInstance(std::string objectName);
 
-		TransformProcessor *EntityInstanceData::getTransformer(int id);
+		TransformProcessor *getTransformer(int id);
 
 		VariableInstanceNameAndIdMap *getVariables() override;
 		UniversalObjectInterface *getVariable(int variableId);

--- a/spriterengine/objectinfo/spriteobjectinfo.cpp
+++ b/spriterengine/objectinfo/spriteobjectinfo.cpp
@@ -3,7 +3,9 @@
 namespace SpriterEngine
 {
 
-	SpriteObjectInfo::SpriteObjectInfo()
+	SpriteObjectInfo::SpriteObjectInfo() :
+		scale(1, 1),
+		alpha(1)
 	{
 	}
 

--- a/spriterengine/timeinfo/easingcurveinterface.h
+++ b/spriterengine/timeinfo/easingcurveinterface.h
@@ -10,6 +10,7 @@ namespace SpriterEngine
 	{
 	public:
 		EasingCurveInterface();
+		virtual ~EasingCurveInterface() = default;
 
 		virtual real adjustedTimeRatio(real timeRatio) = 0;
 

--- a/spriterengine/timeline/timelineinstance.cpp
+++ b/spriterengine/timeline/timelineinstance.cpp
@@ -39,7 +39,7 @@ namespace SpriterEngine
 	void TimelineInstance::findTimeForward(real newTime)
 	{
 		auto& currentIt = timelineKeyIterator;
-		auto& endIt = std::prev(timelineKeys->end());
+		auto endIt = std::prev(timelineKeys->end());
 
 		// if the time to find is below the current time
 		if (newTime<(*currentIt)->getTime())
@@ -76,7 +76,7 @@ namespace SpriterEngine
 	void TimelineInstance::findTimeBackward(real newTime)
 	{
 		auto& currentIt = timelineKeyIterator;
-		auto& endIt = timelineKeys->begin();
+		auto endIt = timelineKeys->begin();
 
 		// if the time to find is above the next time
 		if (newTime > (*currentIt)->getNextTime())

--- a/spriterengine/timeline/triggertimelineinstance.cpp
+++ b/spriterengine/timeline/triggertimelineinstance.cpp
@@ -11,16 +11,16 @@ namespace SpriterEngine
 
 	TriggerTimelineInstance::TriggerTimelineInstance(EntityInstanceData *entityInstanceData, Timeline *timeline, int objectId) :
 		TimelineInstance(timeline),
-		previousTime(0),
-		triggerCount(0)
+		triggerCount(0),
+		previousTime(0)
 	{	
 		resultObject = entityInstanceData->getTriggerObject(objectId);
 	}
 
 	TriggerTimelineInstance::TriggerTimelineInstance(EntityInstanceData * entityInstanceData, Timeline * timeline) :
 		TimelineInstance(timeline),
-		previousTime(0),
-		triggerCount(0)
+		triggerCount(0),
+		previousTime(0)
 	{
 		resultObject = 0;
 	}
@@ -47,7 +47,7 @@ namespace SpriterEngine
 	void TriggerTimelineInstance::findTimeForward(real newTime, real animationLength)
 	{
 		auto& currentIt = timelineKeyIterator;
-		auto& endIt = std::prev(timelineKeys->end());
+		auto endIt = std::prev(timelineKeys->end());
 
 		// if the time to find is below the current time
 		if (newTime < (*currentIt)->getTime())
@@ -109,7 +109,7 @@ namespace SpriterEngine
 	void TriggerTimelineInstance::findTimeBackward(real newTime, real animationLength)
 	{
 		auto& currentIt = timelineKeyIterator;
-		auto& endIt = timelineKeys->begin();
+		auto endIt = timelineKeys->begin();
 
 		// if the time to find is above the next time
 		if (newTime > (*currentIt)->getNextTime())

--- a/spriterengine/variable/variableinstancenameandidmap.cpp
+++ b/spriterengine/variable/variableinstancenameandidmap.cpp
@@ -34,7 +34,7 @@ namespace SpriterEngine
 
 	UniversalObjectInterface *VariableInstanceNameAndIdMap::getVariable(std::string variableName)
 	{
-		auto& it = variableNameMap.find(variableName);
+		auto it = variableNameMap.find(variableName);
 		if (it != variableNameMap.end())
 		{
 			return (*it).second;


### PR DESCRIPTION
- Added virtual destructor to an abstract class ;
- Removed an extra qualifier in a class ;
- Reordered some constructor elements according to `-Wreorder` (note: I didn't do all of them, just in the ones I had compile error in it too) ;
- Fixed r-value references as an STL iterator is almost a pointer, things like `map.find(key)` return a value, not a reference, hence `auto& it = map.find(key)` would keep a reference to a temporary variable.
