### PR TITLE
add virtual destructors to override classes

### DIFF
--- a/spriterengine/file/file.cpp
+++ b/spriterengine/file/file.cpp
@@ -9,6 +9,8 @@ namespace SpriterEngine
 
 	}
 
+	File::~File() {}
+
 	ImageFile *File::imageFile()
 	{
 		return 0;
@@ -23,5 +25,4 @@ namespace SpriterEngine
 	{
 		return filePath;
 	}
-
 }

--- a/spriterengine/file/file.h
+++ b/spriterengine/file/file.h
@@ -13,6 +13,7 @@ namespace SpriterEngine
 	{
 	public:
 		File(std::string initialFilePath);
+		virtual ~File();
 
 		virtual ImageFile *imageFile();
 		virtual SoundFile *soundFile();

--- a/spriterengine/override/imagefile.cpp
+++ b/spriterengine/override/imagefile.cpp
@@ -11,6 +11,8 @@ namespace SpriterEngine
 	{
 	}
 
+	ImageFile::~ImageFile() {}
+
 	ImageFile *ImageFile::imageFile()
 	{
 		return this;

--- a/spriterengine/override/imagefile.h
+++ b/spriterengine/override/imagefile.h
@@ -15,6 +15,7 @@ namespace SpriterEngine
 	{
 	public:
 		ImageFile(std::string initialFilePath, point initialDefaultPivot);
+		virtual ~ImageFile();
 
 		ImageFile *imageFile() override;
 

--- a/spriterengine/override/objectfactory.cpp
+++ b/spriterengine/override/objectfactory.cpp
@@ -12,6 +12,8 @@ namespace SpriterEngine
 	{
 	}
 
+	ObjectFactory::~ObjectFactory() {}
+
 	PointInstanceInfo * ObjectFactory::newPointInstanceInfo()
 	{
 		return new PointInstanceInfo();

--- a/spriterengine/override/objectfactory.h
+++ b/spriterengine/override/objectfactory.h
@@ -17,6 +17,7 @@ namespace SpriterEngine
 	{
 	public:
 		ObjectFactory();
+		virtual ~ObjectFactory();
 		
 		// TODO: Override along with PointObjectInfo::render() to allow debug display of point objects;
 		virtual PointInstanceInfo *newPointInstanceInfo();

--- a/spriterengine/override/soundfile.cpp
+++ b/spriterengine/override/soundfile.cpp
@@ -9,6 +9,8 @@ namespace SpriterEngine
 	{
 	}
 
+	SoundFile::~SoundFile() {}
+
 	SoundFile *SoundFile::soundFile()
 	{
 		return this;

--- a/spriterengine/override/soundfile.h
+++ b/spriterengine/override/soundfile.h
@@ -10,6 +10,7 @@ namespace SpriterEngine
 	{
 	public:
 		SoundFile(std::string initialFilePath);
+		virtual ~SoundFile();
 
 		SoundFile *soundFile();
 

--- a/spriterengine/override/soundobjectinforeference.cpp
+++ b/spriterengine/override/soundobjectinforeference.cpp
@@ -12,6 +12,8 @@ namespace SpriterEngine
 	{
 	}
 
+	SoundObjectInfoReference::~SoundObjectInfoReference() {}
+
 	int SoundObjectInfoReference::getTriggerCount()
 	{
 		return triggerCount;

--- a/spriterengine/override/soundobjectinforeference.h
+++ b/spriterengine/override/soundobjectinforeference.h
@@ -12,6 +12,7 @@ namespace SpriterEngine
 	{
 	public:
 		SoundObjectInfoReference();
+		virtual ~SoundObjectInfoReference();
 
 		int getTriggerCount() override;
 


### PR DESCRIPTION
Declaring virtual destructors and implementing them in the base class makes it safe for sub-classes to declare their own destructors, as they will be automatically called when a upcasted reference is deleted.
