### PR TITLE
Don't keep SpriterFileDocumentWrapper references

### DIFF
--- a/spriterengine/loading/loader.cpp
+++ b/spriterengine/loading/loader.cpp
@@ -3,31 +3,32 @@
 #include "../global/settings.h"
 
 #include "../override/spriterfiledocumentwrapper.h"
+#include "../override/filefactory.h"
 
 namespace SpriterEngine
 {
-	Loader::Loader(SpriterFileDocumentWrapper * newScmlDocumentWrapper, SpriterFileDocumentWrapper * newSconDocumentWrapper) :
-		scmlDocumentWrapper(newScmlDocumentWrapper),
-		sconDocumentWrapper(newSconDocumentWrapper)
+	Loader::Loader(FileFactory * newFileFactory) :
+		fileFactory(newFileFactory)
 	{
 	}
 
 	Loader::~Loader()
 	{
-		delete scmlDocumentWrapper;
-		delete sconDocumentWrapper;
 	}
 
 	void Loader::loadFile(SpriterModel * model, const std::string &fileName)
 	{
+		SpriterDocumentLoader spriterDocumentLoader;
+		SpriterFileDocumentWrapper * wrapper = nullptr;
 
 		SpriterFileType fileType = extractFileTypeFromFileName(fileName);
 		switch (fileType)
 		{
 		case SPRITERFILETYPE_SCML:
-			if (scmlDocumentWrapper)
+			wrapper = fileFactory->newScmlDocumentWrapper();
+			if (wrapper)
 			{
-				spriterDocumentLoader.loadFile(model, scmlDocumentWrapper, fileName);
+				spriterDocumentLoader.loadFile(model, wrapper, fileName);
 			}
 			else
 			{
@@ -36,9 +37,10 @@ namespace SpriterEngine
 			break;
 
 		case SPRITERFILETYPE_SCON:
-			if (sconDocumentWrapper)
+			wrapper = fileFactory->newSconDocumentWrapper();
+			if (wrapper)
 			{
-				spriterDocumentLoader.loadFile(model, sconDocumentWrapper, fileName);
+				spriterDocumentLoader.loadFile(model, wrapper, fileName);
 			}
 			else
 			{
@@ -50,6 +52,7 @@ namespace SpriterEngine
 			Settings::error("Loader::loadFile - attempting to load file \"" + fileName + "\" : unrecognized file type");
 			break;
 		}
+		delete wrapper;
 	}
 
 	Loader::SpriterFileType Loader::extractFileTypeFromFileName(const std::string &fileName)

--- a/spriterengine/loading/loader.h
+++ b/spriterengine/loading/loader.h
@@ -10,11 +10,12 @@ namespace SpriterEngine
 
 	class SpriterFileDocumentWrapper;
 	class SpriterModel;
+	class FileFactory;
 
 	class Loader
 	{
 	public:
-		Loader(SpriterFileDocumentWrapper *newScmlDocumentWrapper, SpriterFileDocumentWrapper *newSconDocumentWrapper);
+		Loader(FileFactory *newFileFactory);
 		~Loader();
 
 		void loadFile(SpriterModel *model, const std::string &fileName);
@@ -26,11 +27,8 @@ namespace SpriterEngine
 			SPRITERFILETYPE_SCML,
 			SPRITERFILETYPE_SCON
 		};
-		
-		SpriterDocumentLoader spriterDocumentLoader;
 
-		SpriterFileDocumentWrapper *scmlDocumentWrapper;
-		SpriterFileDocumentWrapper *sconDocumentWrapper;
+		FileFactory *fileFactory;
 
 		SpriterFileType extractFileTypeFromFileName(const std::string &fileName);
 	};

--- a/spriterengine/model/spritermodel.cpp
+++ b/spriterengine/model/spritermodel.cpp
@@ -23,7 +23,7 @@ namespace SpriterEngine
 	SpriterModel::SpriterModel(FileFactory * newFileFactory, ObjectFactory * newObjectFactory) :
 		fileFactory(newFileFactory),
 		objectFactory(newObjectFactory),
-		loader(newFileFactory->newScmlDocumentWrapper(), newFileFactory->newSconDocumentWrapper())
+		loader(newFileFactory)
 	{
 	}
 


### PR DESCRIPTION
They just keep up memory. Fi of all the nodes

The difference in memory in my example is 5MB
