### PR TITLE
Fixed compilation error and made __USE_PUGIXML standard

### DIFF
--- a/example/override/examplefilefactory.cpp
+++ b/example/override/examplefilefactory.cpp
@@ -4,7 +4,7 @@
 #include "../../spriterengine/override/soundfile.h"
 
 // #define __USE_PUGIXML
-#if not defined(__USE_PUGIXML)
+#ifndef __USE_PUGIXML
 #include "tinyxmlspriterfiledocumentwrapper.h"
 #else
 #include "pugixmlspriterfiledocumentwrapper.h"
@@ -33,7 +33,7 @@ namespace SpriterEngine
 
 	SpriterFileDocumentWrapper * ExampleFileFactory::newScmlDocumentWrapper()
 	{
-#if not defined(__USE_PUGIXML)
+#ifndef __USE_PUGIXML
 		return new TinyXmlSpriterFileDocumentWrapper();
 #else
 		return new PugiXmlSpriterFileDocumentWrapper();		

--- a/spriterengine/override/objectfactory.h
+++ b/spriterengine/override/objectfactory.h
@@ -7,11 +7,11 @@
 
 namespace SpriterEngine
 {
-
 	class PointInstanceInfo;
 	class BoneInstanceInfo;
 	class BoxInstanceInfo;
 	class TriggerObjectInfo;
+	class SpriteObjectInfo;
 
 	class ObjectFactory
 	{


### PR DESCRIPTION
Compilation error introduced in 750630c0edb297281f981ccd429a008198ecab6f

From a missing forward declaration of SpriteObjectInfo.

Also changed `__USE_PUGIXML` macros in examplefilefactory to use `#ifndef`.
