### PR TITLE
Remove ambiguity regarding expression evaluation order

### DIFF
--- a/spriterengine/entity/entity.cpp
+++ b/spriterengine/entity/entity.cpp
@@ -115,7 +115,8 @@ namespace SpriterEngine
 		}
 		else
 		{
-			return objectIdMap[objectNameMap.size()] = (&(*objectNameMap.insert(std::make_pair(objectName, Object(objectName, objectNameMap.size(), objectType))).first).second);
+			int size = objectNameMap.size();
+			return objectIdMap[size] = (&(*objectNameMap.insert(std::make_pair(objectName, Object(objectName, size, objectType))).first).second);
 		}
 	}
 
@@ -128,7 +129,8 @@ namespace SpriterEngine
 		}
 		else
 		{
-			return soundIdMap[objectNameMap.size()] = (&(*objectNameMap.insert(std::make_pair(objectName, Object(objectName, objectNameMap.size(), Object::OBJECTTYPE_SOUND))).first).second);
+			int size = objectNameMap.size();
+			return soundIdMap[size] = (&(*objectNameMap.insert(std::make_pair(objectName, Object(objectName, size, Object::OBJECTTYPE_SOUND))).first).second);
 		}
 	}
 
@@ -141,7 +143,8 @@ namespace SpriterEngine
 		}
 		else
 		{
-			return triggerIdMap[objectNameMap.size()] = (&(*objectNameMap.insert(std::make_pair(objectName, Object(objectName, objectNameMap.size(), Object::OBJECTTYPE_TRIGGER))).first).second);
+			int size = objectNameMap.size();
+			return triggerIdMap[size] = (&(*objectNameMap.insert(std::make_pair(objectName, Object(objectName, size, Object::OBJECTTYPE_TRIGGER))).first).second);
 		}
 	}
 
@@ -154,7 +157,8 @@ namespace SpriterEngine
 		}
 		else
 		{
-			return subEntityIdMap[objectNameMap.size()] = (&(*objectNameMap.insert(std::make_pair(objectName, Object(objectName, objectNameMap.size(), Object::OBJECTTYPE_ENTITY))).first).second);
+			int size = objectNameMap.size();
+			return subEntityIdMap[size] = (&(*objectNameMap.insert(std::make_pair(objectName, Object(objectName, size, Object::OBJECTTYPE_ENTITY))).first).second);
 		}
 	}
 


### PR DESCRIPTION
With some compilers, expressions on the right-hand side of the assignment will be evaluated before the left-hand side. That results in IDs being one off, and can result in awkward behavior or crashes.

(Experienced this on OS X El Capitan with Apple LLVM 7.0.2 clang-700.1.81 to be absolutely precise)
