### PR TITLE
Eliminate redundant setupInstance call

### DIFF
--- a/spriterengine/entity/entityinstance.cpp
+++ b/spriterengine/entity/entityinstance.cpp
@@ -47,7 +47,6 @@ namespace SpriterEngine
 	{
 		model->setupFileReferences(&files);
 		currentEntity = (*entities.insert(std::make_pair(entity->getId(), new EntityInstanceData(model, this, entity, objectFactory))).first).second;
-		entity->setupInstance(model, this, currentEntity, objectFactory);
 		setCurrentAnimation(0);
 	}
 


### PR DESCRIPTION
EntityInstanceData constructor already calls entity->setupInstance, it is not needed in EntityInstance constructor and is causing error messages to be logged e.g.:

```
SpriterPlusPlus error: EntityInstanceData::setObjectInstance - object with id "21" already exists
SpriterPlusPlus error: EntityInstanceData::setTagInstance - tag with id "21" already exists
```
