### PR TITLE
Adds missing include directives.

### DIFF
--- a/spriterengine/animation/animation.h
+++ b/spriterengine/animation/animation.h
@@ -2,6 +2,7 @@
 #define ANIMATION_H
 
 #include <vector>
+#include <string>
 
 #include "../timeline/timeline.h"
 

--- a/spriterengine/animation/animationinstance.h
+++ b/spriterengine/animation/animationinstance.h
@@ -2,6 +2,7 @@
 #define ANIMATIONINSTANCE_H
 
 #include <vector>
+#include <string>
 
 #include "mainlinekeyinstance.h"
 

--- a/spriterengine/variable/variableinstancenameandidmap.h
+++ b/spriterengine/variable/variableinstancenameandidmap.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <map>
+#include <string>
 
 namespace SpriterEngine
 {


### PR DESCRIPTION
Some header files used std::string without including the <string>
header, causing builds to fail.  This commit adds the missing
include directives.