### PR TITLE
Added interface to access calculated animation bounds.

### DIFF
--- a/spriterengine/animation/animation.h
+++ b/spriterengine/animation/animation.h
@@ -32,6 +32,11 @@ namespace SpriterEngine
 		std::string getName();
 		real getLength();
 		bool getIsLooping();
+		
+		point getBoundsPosition() const { return boundsPosition; }
+		void setBoundsPosition(point position) { boundsPosition = position; }
+		point getBoundsSize() const { return boundsSize; }
+		void setBoundsSize(point size) { boundsSize = size; }
 
 		void setupAnimationInstance(EntityInstance *entityInstance, EntityInstanceData *entityInstanceData, MainlineKeyInstanceVector *mainlineKeyInstances, TimelineInstanceVector *timelineInstances, real *length, bool *looping);
 
@@ -58,7 +63,9 @@ namespace SpriterEngine
 		TimelineVector tagTimelines;
 		TimelineVector soundTimelines;
 		TimelineVector triggerTimelines;
-
+		
+		point boundsPosition;
+		point boundsSize;
 		real animationLength;
 		bool isLooping;
 	};

--- a/spriterengine/entity/entity.cpp
+++ b/spriterengine/entity/entity.cpp
@@ -51,7 +51,12 @@ namespace SpriterEngine
 		entityInstanceData->setTagInstance(THIS_ENTITY, "");
 		setupAnimationInstances(entityInstance, entityInstanceData);
 	}
-
+	
+	AnimationVector* Entity::getAnimations()
+	{
+		return &animations;
+	}
+	
 	Object *Entity::setObject(std::string objectName, Object::ObjectType objectType)
 	{
 		switch (objectType)

--- a/spriterengine/entity/entity.h
+++ b/spriterengine/entity/entity.h
@@ -39,6 +39,7 @@ namespace SpriterEngine
 		EntityInstance *getNewEntityInstance(SpriterModel *model, ObjectFactory *objectFactory);
 		void setupInstance(SpriterModel *model, EntityInstance *entityInstance, EntityInstanceData *entityInstanceData, ObjectFactory *objectFactory);
 
+		AnimationVector* getAnimations();
 		Animation *pushBackAnimation(std::string animationName, real length, bool looping);
 		
 		Object *setObject(std::string objectName, Object::ObjectType objectType);

--- a/spriterengine/loading/spriterdocumentloader.cpp
+++ b/spriterengine/loading/spriterdocumentloader.cpp
@@ -699,10 +699,10 @@ namespace SpriterEngine
 
 	Animation *SpriterDocumentLoader::getNewAnimationFromAnimationElement(SpriterFileElementWrapper *animationElement, Entity *entity)
 	{
-		Animation *newAnimation = 0;
 		real animationLength = 0;
 		bool animationLooping = true;
 		SpriterFileAttributeWrapper *att = animationElement->getFirstAttribute("name");
+		SpriterFileAttributeWrapper *att2 = nullptr;
 		if (att->isValid())
 		{
 			std::string animationName = att->getStringValue();
@@ -724,7 +724,23 @@ namespace SpriterEngine
 				animationLooping = att->getStringValue() != "false";
 			}
 
-			return entity->pushBackAnimation(animationName, animationLength, animationLooping);
+			Animation *newAnimation = entity->pushBackAnimation(animationName, animationLength, animationLooping);
+			att = animationElement->getFirstAttribute("l");
+			att2 = animationElement->getFirstAttribute("t");
+			if (att->isValid() && att2->isValid())
+			{
+				real l = att->getRealValue(), t = att2->getRealValue();
+				newAnimation->setBoundsPosition({ l, t });
+				
+				att = animationElement->getFirstAttribute("r");
+				att2 = animationElement->getFirstAttribute("b");
+				if (att->isValid() && att2->isValid())
+				{
+					real r = att->getRealValue(), b = att2->getRealValue();
+					newAnimation->setBoundsSize({ r - l, b - t });
+				}
+			}
+			return newAnimation;
 		}
 		else
 		{

--- a/spriterengine/model/spritermodel.cpp
+++ b/spriterengine/model/spritermodel.cpp
@@ -121,6 +121,11 @@ namespace SpriterEngine
 			fileReferences->push_back(new FileReference(it));
 		}
 	}
+	
+	EntityVector* SpriterModel::getEntities()
+	{
+		return &entities;
+	}
 
 	Entity *SpriterModel::pushBackEntity(std::string entityName)
 	{

--- a/spriterengine/model/spritermodel.h
+++ b/spriterengine/model/spritermodel.h
@@ -39,6 +39,7 @@ namespace SpriterEngine
 		void appendEntityToInstanceByName(EntityInstance * entityInstance, std::string entityName);
 		void setupFileReferences(FileReferenceVector *fileReferences);
 
+		EntityVector* getEntities();
 		Entity *pushBackEntity(std::string entityName);
 		void pushBackImageFile(std::string initialFilePath, point initialDefaultPivot, atlasdata atlasData);
 		void pushBackSoundFile(std::string initialFilePath);


### PR DESCRIPTION
Animation bounds are not exposed in the current SpriterPlusPlus so they cannot be accessed by engine code.
This commits also allows accessing entities for a model and animations for those entities.